### PR TITLE
Fixed bullets not displaying in s03_turret

### DIFF
--- a/s03_turret/Canon.pde
+++ b/s03_turret/Canon.pde
@@ -18,7 +18,7 @@ class Canon extends GraphicObject {
   }
   
   PVector getCanonTip() {
-    
+    move(0);
     return canonTip;
   }
   


### PR DESCRIPTION
### Fixed the bullets not displaying when shooting without having moved the canon.
Fixed the bug by calling the method 'move' with the parameter direction at 0, so we have the right canonTip position.

