### PR TITLE
Add PVector force simulator with toggleable forces

### DIFF
--- a/xtra/s02_forces_simulator/CheckBox.pde
+++ b/xtra/s02_forces_simulator/CheckBox.pde
@@ -1,0 +1,42 @@
+class CheckBox extends GraphicObject<PApplet> {
+  float x, y, size;
+  String label;
+  boolean checked = true;
+  boolean wasPressed = false;
+
+  CheckBox(PApplet app, float x, float y, float size, String label) {
+    super(app);
+    this.x = x;
+    this.y = y;
+    this.size = size;
+    this.label = label;
+  }
+
+  boolean over() {
+    return app.mouseX >= x && app.mouseX <= x + size &&
+           app.mouseY >= y && app.mouseY <= y + size;
+  }
+
+  @Override
+  void update(int deltaTime) {
+    if (app.mousePressed && !wasPressed && over()) {
+      checked = !checked;
+    }
+    wasPressed = app.mousePressed;
+  }
+
+  @Override
+  void display() {
+    app.stroke(0);
+    app.fill(checked ? 0 : 255);
+    app.rect(x, y, size, size);
+    if (checked) {
+      app.stroke(255);
+      app.line(x, y, x + size, y + size);
+      app.line(x, y + size, x + size, y);
+    }
+    app.fill(0);
+    app.textAlign(LEFT, CENTER);
+    app.text(label, x + size + 4, y + size / 2);
+  }
+}

--- a/xtra/s02_forces_simulator/GraphicObject.pde
+++ b/xtra/s02_forces_simulator/GraphicObject.pde
@@ -1,0 +1,8 @@
+abstract class GraphicObject<T extends PApplet> {
+  protected T app;
+  GraphicObject(T app) {
+    this.app = app;
+  }
+  abstract void update(int deltaTime);
+  abstract void display();
+}

--- a/xtra/s02_forces_simulator/Mover.pde
+++ b/xtra/s02_forces_simulator/Mover.pde
@@ -1,0 +1,52 @@
+class Mover extends GraphicObject<PApplet> {
+  PVector position;
+  PVector velocity;
+  PVector acceleration;
+  float mass;
+
+  Mover(PApplet app, float x, float y, float mass) {
+    super(app);
+    this.position = new PVector(x, y);
+    this.velocity = new PVector();
+    this.acceleration = new PVector();
+    this.mass = mass;
+  }
+
+  void applyForce(PVector force) {
+    PVector f = force.copy();
+    f.div(mass);
+    acceleration.add(f);
+  }
+
+  @Override
+  void update(int deltaTime) {
+    float dt = deltaTime / 1000.0f;
+    velocity.add(PVector.mult(acceleration, dt));
+    position.add(PVector.mult(velocity, dt));
+
+    // simple bounce on window edges
+    if (position.x < 0) {
+      position.x = 0;
+      velocity.x *= -1;
+    } else if (position.x > app.width) {
+      position.x = app.width;
+      velocity.x *= -1;
+    }
+    if (position.y < 0) {
+      position.y = 0;
+      velocity.y *= -1;
+    } else if (position.y > app.height) {
+      position.y = app.height;
+      velocity.y *= -1;
+    }
+
+    acceleration.mult(0);
+  }
+
+  @Override
+  void display() {
+    app.fill(200, 0, 0);
+    app.noStroke();
+    app.ellipse(position.x, position.y, mass * 16, mass * 16);
+  }
+}

--- a/xtra/s02_forces_simulator/s02_forces_simulator.pde
+++ b/xtra/s02_forces_simulator/s02_forces_simulator.pde
@@ -1,0 +1,61 @@
+Mover mover;
+CheckBox cbGravity, cbWind, cbFriction, cbCenter;
+int previousTime;
+
+void setup() {
+  size(800, 600);
+  mover = new Mover(this, width/2, height/2, 2);
+  cbGravity = new CheckBox(this, 20, 20, 20, "Gravité");
+  cbWind = new CheckBox(this, 20, 50, 20, "Vent");
+  cbFriction = new CheckBox(this, 20, 80, 20, "Friction");
+  cbCenter = new CheckBox(this, 20, 110, 20, "Centripète");
+  previousTime = millis();
+  textSize(12);
+}
+
+void draw() {
+  int currentTime = millis();
+  int deltaTime = currentTime - previousTime;
+  previousTime = currentTime;
+
+  background(255);
+
+  // update UI
+  cbGravity.update(deltaTime);
+  cbWind.update(deltaTime);
+  cbFriction.update(deltaTime);
+  cbCenter.update(deltaTime);
+
+  // apply forces
+  if (cbGravity.checked) {
+    PVector gravity = new PVector(0, 9.81f * mover.mass);
+    mover.applyForce(gravity);
+  }
+  if (cbWind.checked) {
+    PVector wind = new PVector(5f, 0);
+    mover.applyForce(wind);
+  }
+  if (cbFriction.checked) {
+    PVector friction = mover.velocity.copy();
+    if (friction.mag() > 0) {
+      friction.normalize();
+      friction.mult(-0.5f);
+      mover.applyForce(friction);
+    }
+  }
+  if (cbCenter.checked) {
+    PVector center = PVector.sub(new PVector(width/2, height/2), mover.position);
+    center.mult(0.5f);
+    mover.applyForce(center);
+  }
+
+  // update and display mover
+  mover.update(deltaTime);
+  mover.display();
+
+  // display UI
+  cbGravity.display();
+  cbWind.display();
+  cbFriction.display();
+  cbCenter.display();
+}

--- a/xtra/s02_forces_simulator/sketch.properties
+++ b/xtra/s02_forces_simulator/sketch.properties
@@ -1,0 +1,2 @@
+mode.id=processing.mode.java.JavaMode
+mode=Java


### PR DESCRIPTION
## Summary
- Add new Processing sketch `s02_forces_simulator` demonstrating forces using `PVector`
- Implement abstract generic `GraphicObject` base class for update/display
- Include `Mover` and `CheckBox` classes to toggle gravity, wind, friction and centripetal forces
- Move sketch into `xtra` directory for better organization

## Testing
- `processing-java --sketch=xtra/s02_forces_simulator --build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6eda6d2b08331966ae0e0ae166441